### PR TITLE
fix to error caused by pre-existing tmux.conf

### DIFF
--- a/tmux-launch
+++ b/tmux-launch
@@ -35,9 +35,10 @@ start-tmux-session() {
     echo "Starting service-runner tmux session: ${_SESSION_ID}"
     tmux start-server
     tmux new-session -d -s ${_SESSION_ID}
+    tmux send-keys "tmux set -g base-index 0" C-m
     if [ "$?" -ne "0" ]; then 
-	attach-tmux-session
-	exit 1
+	    attach-tmux-session
+	    exit 1
     fi
 }
 


### PR DESCRIPTION
having base-index 1 in config caused multiple problems:
```
window not found: example_ui-dev:0
window not found: example_ui-dev:0
window not found: example_ui-dev:0
window not found: example_ui-dev:0
window not found: example_ui-dev:0
create window failed: index in use: 1
```

adding line 

`tmux send-keys "tmux set -g base-index 0" C-m`

fixed by overriding pre-existing config